### PR TITLE
make max submissions optional

### DIFF
--- a/src/scripts/controllers/exam-controller.js
+++ b/src/scripts/controllers/exam-controller.js
@@ -12,8 +12,8 @@ angular
     $scope.isValidStartTime = () => isBefore();
     $scope.isValidEndTime = () => isBefore();
     $scope.isValidDuration = () => !$scope.hasDuration || $scope.exam.duration > 0;
-    $scope.isValidMaxProblemSubmissions = () => !!$scope.exam.max_problem_submissions && $scope.exam.max_problem_submissions > 0;
-    $scope.isValidMaxChoiceSubmissions = () => !!$scope.exam.max_choice_submissions && $scope.exam.max_choice_submissions > 0;
+    $scope.isValidMaxProblemSubmissions = () => !$scope.exam.max_problem_submissions || $scope.exam.max_problem_submissions > 0;
+    $scope.isValidMaxChoiceSubmissions = () => !$scope.exam.max_choice_submissions || $scope.exam.max_choice_submissions > 0;
     $scope.isValidPassingCriterion = () => !!$scope.passing_criterion && $scope.passing_criterion.type && $scope.passing_criterion.type.isValid($scope.passing_criterion.value);
 
     $scope.isValidMandatoryFields = () =>


### PR DESCRIPTION
Related to mumuki/mumuki-platform#321.

It's not quite enough to fix it though. New exams created with no submission limits will be ok, but can't edit an exam to remove them because null fields are not imported.